### PR TITLE
Skip through song while playing, Envelope improvements, Scopes on/off

### DIFF
--- a/options.lfm
+++ b/options.lfm
@@ -1,38 +1,51 @@
 object frmOptions: TfrmOptions
-  Left = 1762
-  Height = 849
-  Top = 212
-  Width = 762
+  Left = 660
+  Height = 485
+  Top = 573
+  Width = 435
   BorderStyle = bsDialog
   Caption = 'Options'
-  ClientHeight = 849
-  ClientWidth = 762
-  DesignTimePPI = 168
+  ClientHeight = 485
+  ClientWidth = 435
   Position = poMainFormCenter
   LCLVersion = '2.0.6.0'
   object Label1: TLabel
-    Left = 24
-    Height = 30
-    Top = 24
-    Width = 211
+    Left = 14
+    Height = 15
+    Top = 14
+    Width = 119
     Caption = 'Pattern editor font size'
     ParentColor = False
+    ParentFont = False
   end
   object Button1: TButton
-    Left = 520
-    Height = 44
-    Top = 784
-    Width = 216
+    Left = 297
+    Height = 25
+    Top = 448
+    Width = 123
     Caption = 'OK'
     OnClick = Button1Click
+    ParentFont = False
     TabOrder = 0
   end
   object FontSizeSpinner: TSpinEdit
-    Left = 272
-    Height = 38
-    Top = 16
-    Width = 216
+    Left = 155
+    Height = 23
+    Top = 9
+    Width = 123
+    ParentFont = False
     TabOrder = 1
     Value = 12
+  end
+  object ScopesCheck: TCheckBox
+    Left = 14
+    Height = 19
+    Top = 40
+    Width = 149
+    Alignment = taLeftJustify
+    Caption = 'Scopes (Uses More CPU)'
+    Checked = True
+    State = cbChecked
+    TabOrder = 2
   end
 end

--- a/options.pas
+++ b/options.pas
@@ -13,6 +13,7 @@ type
 
   TfrmOptions = class(TForm)
     Button1: TButton;
+    ScopesCheck: TCheckBox;
     Label1: TLabel;
     FontSizeSpinner: TSpinEdit;
     procedure Button1Click(Sender: TObject);

--- a/tracker.lfm
+++ b/tracker.lfm
@@ -1,11 +1,11 @@
 object frmTracker: TfrmTracker
-  Left = 434
-  Height = 661
-  Top = 645
+  Left = 453
+  Height = 701
+  Top = 598
   Width = 1145
   AllowDropFiles = True
   Caption = 'hUGETracker'
-  ClientHeight = 641
+  ClientHeight = 681
   ClientWidth = 1145
   KeyPreview = True
   Menu = MainMenu1
@@ -21,8 +21,8 @@ object frmTracker: TfrmTracker
   LCLVersion = '2.0.6.0'
   object TreeView1: TTreeView
     Left = 0
-    Height = 530
-    Top = 88
+    Height = 569
+    Top = 89
     Width = 193
     Align = alLeft
     ParentFont = False
@@ -42,30 +42,30 @@ object frmTracker: TfrmTracker
   end
   object Splitter1: TSplitter
     Left = 193
-    Height = 530
-    Top = 88
+    Height = 569
+    Top = 89
     Width = 5
   end
   object Panel1: TPanel
     Left = 198
-    Height = 530
-    Top = 88
+    Height = 569
+    Top = 89
     Width = 947
     Align = alClient
     BevelOuter = bvNone
-    ClientHeight = 530
+    ClientHeight = 569
     ClientWidth = 947
     ParentFont = False
     TabOrder = 2
     object PageControl1: TPageControl
       Left = 0
-      Height = 530
+      Height = 569
       Top = 0
       Width = 947
-      ActivePage = CommentsTabSheet
+      ActivePage = PatternTabSheet
       Align = alClient
       ParentFont = False
-      TabIndex = 4
+      TabIndex = 1
       TabOrder = 0
       object GeneralTabSheet: TTabSheet
         Caption = 'General'
@@ -146,16 +146,16 @@ object frmTracker: TfrmTracker
       end
       object PatternTabSheet: TTabSheet
         Caption = 'Patterns'
-        ClientHeight = 502
+        ClientHeight = 541
         ClientWidth = 939
         ParentFont = False
         object Panel3: TPanel
           Left = 224
-          Height = 502
+          Height = 541
           Top = 0
           Width = 715
           Align = alClient
-          ClientHeight = 502
+          ClientHeight = 541
           ClientWidth = 715
           ParentFont = False
           TabOrder = 0
@@ -204,7 +204,7 @@ object frmTracker: TfrmTracker
           end
           object ScrollBox1: TScrollBox
             Left = 1
-            Height = 470
+            Height = 509
             Top = 31
             Width = 713
             HorzScrollBar.Increment = 1
@@ -225,7 +225,7 @@ object frmTracker: TfrmTracker
         end
         object OrderEditStringGrid: TStringGrid
           Left = 0
-          Height = 502
+          Height = 541
           Top = 0
           Width = 224
           Align = alLeft
@@ -1589,19 +1589,20 @@ object frmTracker: TfrmTracker
   end
   object Panel2: TPanel
     Left = 0
-    Height = 63
+    Height = 64
     Top = 25
     Width = 1145
     Align = alTop
     BevelOuter = bvNone
-    ClientHeight = 63
+    Caption = 'Hides if Scopes Off'
+    ClientHeight = 64
     ClientWidth = 1145
     ParentFont = False
     TabOrder = 3
     object LEDMeter1: TLEDMeter
       AnchorSideRight.Control = Duty1Visualizer
       Left = 0
-      Height = 31
+      Height = 32
       Top = 32
       Width = 357
       Anchors = [akTop, akLeft, akRight]
@@ -1646,7 +1647,7 @@ object frmTracker: TfrmTracker
     end
     object Duty1Visualizer: TPaintBox
       Left = 357
-      Height = 63
+      Height = 64
       Top = 0
       Width = 197
       Align = alRight
@@ -1656,7 +1657,7 @@ object frmTracker: TfrmTracker
     end
     object Duty2Visualizer: TPaintBox
       Left = 554
-      Height = 63
+      Height = 64
       Top = 0
       Width = 197
       Align = alRight
@@ -1666,7 +1667,7 @@ object frmTracker: TfrmTracker
     end
     object WaveVisualizer: TPaintBox
       Left = 751
-      Height = 63
+      Height = 64
       Top = 0
       Width = 197
       Align = alRight
@@ -1676,7 +1677,7 @@ object frmTracker: TfrmTracker
     end
     object NoiseVisualizer: TPaintBox
       Left = 948
-      Height = 63
+      Height = 64
       Top = 0
       Width = 197
       Align = alRight
@@ -1688,7 +1689,7 @@ object frmTracker: TfrmTracker
   object StatusBar1: TStatusBar
     Left = 0
     Height = 23
-    Top = 618
+    Top = 658
     Width = 1145
     AutoHint = True
     Panels = <    

--- a/tracker.pas
+++ b/tracker.pas
@@ -544,8 +544,8 @@ var
 begin
   W := PB.Width;
   H := PB.Height-3;
-  V := CurrentInstrument^.InitialVolume;
-  S := CurrentInstrument^.VolSweepAmount*2;
+  V := Min(CurrentInstrument^.InitialVolume,15);
+  S := Min(CurrentInstrument^.VolSweepAmount,7)*2;
   case CurrentInstrument^.LengthEnabled of
     True:   L := (64-CurrentInstrument^.Length) div 2;
     False:  L := 400;
@@ -564,6 +564,7 @@ begin
        LineTo(L*Interval, H-V*HInterval); // no sweep
        MoveTo(L*Interval, H-(V*HInterval));
        LineTo(L*Interval, H);
+       LineTo(W, H);
     end
     else begin
       case CurrentInstrument^.VolSweepDirection of
@@ -571,15 +572,14 @@ begin
            For I := 0 to V do
               LineTo( Min(I*S,L)*Interval, H-(V-I)*HInterval);
            LineTo(W, H);
-           MoveTo(Trunc(L*Interval), 0);
            LineTo(Trunc(L*Interval), H);
            end;
         Up: begin    // Envelope up, check length cut
             For I := 0 to 15-V do
                 LineTo( Min(I*S,L)*Interval, (15-V-I)*HInterval+9);
             LineTo(L*Interval, H-15*HInterval);
-            MoveTo(L*Interval, 0);
             LineTo(L*Interval, H);
+            LineTo(W, H);
             end;
         end;
     end;
@@ -1621,6 +1621,7 @@ end;
 procedure TfrmTracker.InstrumentNumberSpinnerChange(Sender: TObject);
 begin
   LoadInstrument(CurrentInstrumentBank, InstrumentNumberSpinner.Value);
+  DrawEnvelope(EnvelopePaintBox);
 end;
 
 procedure TfrmTracker.LengthSpinnerChange(Sender: TObject);

--- a/tracker.pas
+++ b/tracker.pas
@@ -376,6 +376,7 @@ type
     Playing: Boolean;
     LoadingFile: Boolean;
     SaveSucceeded: Boolean;
+    ScopesOn: Boolean;
 
     {PatternsNode, }
     WaveInstrumentsNode,
@@ -904,6 +905,7 @@ begin
   TrackerGrid.OnResize:=@OnTrackerGridResize;
 
   TrackerGrid.FontSize := OptionsFile.ReadInteger('hUGETracker', 'fontsize', 12);
+  ScopesOn := OptionsFile.ReadBool('hUGETracker', 'ScopesOn', True);
 
   // Fix the size of the channel headers
   for Section in HeaderControl1.Sections do
@@ -1182,7 +1184,8 @@ begin
   ResetEmulationThread; //TODO: remove this hack
 
   // Start the Oscilloscope repaint timer
-  OscilloscopeUpdateTimer.Enabled := True;
+  OscilloscopeUpdateTimer.Enabled := ScopesOn;
+  Panel2.height :=  IfThen(ScopesOn, 64, 0);
 
   // Switch to general tab sheet
   PageControl1.ActivePageIndex := 0;
@@ -1800,10 +1803,16 @@ end;
 procedure TfrmTracker.MenuItem26Click(Sender: TObject);
 begin
   frmOptions.FontSizeSpinner.Value := TrackerGrid.FontSize;
+  frmOptions.ScopesCheck.Checked := ScopesOn;
   frmOptions.ShowModal;
   TrackerGrid.FontSize := frmOptions.FontSizeSpinner.Value;
+  ScopesOn := frmOptions.ScopesCheck.Checked;
 
   OptionsFile.WriteInteger('hUGETracker', 'fontsize', TrackerGrid.FontSize);
+  OptionsFile.WriteBool('hUGETracker', 'ScopesOn', ScopesOn);
+  OscilloscopeUpdateTimer.Enabled := ScopesOn;
+  Panel2.height :=  IfThen(ScopesOn, 64, 0);
+
 end;
 
 procedure TfrmTracker.MenuItem31Click(Sender: TObject);
@@ -1888,6 +1897,20 @@ procedure TfrmTracker.OrderEditStringGridAfterSelection(Sender: TObject; aCol,
 begin
   if OrderEditStringGrid.Row > -1 then
     ReloadPatterns;
+
+  if Playing = True then begin
+     if TrackerGrid.HighlightedRow <> 0 then begin
+        if OrderEditStringGrid.Row = 1 then begin
+           if PreparePreview then
+              Playing := True;
+        end
+        else begin
+            PokeSymbol(SYM_CURRENT_ORDER, 2*(OrderEditStringGrid.Row-2));
+            PokeSymbol(SYM_ROW, 63);
+        end;
+     end;
+     EmulationThread.Start;
+  end
 end;
 
 procedure TfrmTracker.OrderEditStringGridColRowDeleted(Sender: TObject;
@@ -1923,11 +1946,25 @@ procedure TfrmTracker.OrderEditStringGridDblClick(Sender: TObject);
 var
   Highest: Integer;
 begin
-  Highest := Song.Patterns.MaxKey;
+  if Playing = True then begin
+     if  OrderEditStringGrid.Row = 1 then begin
+        if PreparePreview then begin
+           Playing := True;
+        end;
+     end
+     else begin
+       PokeSymbol(SYM_CURRENT_ORDER, 2*(OrderEditStringGrid.Row-2));
+       PokeSymbol(SYM_ROW, 63);
+     end;
+     EmulationThread.Start;
+  end
+  else begin
+    Highest := Song.Patterns.MaxKey;
 
-  with OrderEditStringGrid do begin
-    Cells[Col, Row] := IntToStr(Highest);
-    TrackerGrid.LoadPattern(Col - 1, Highest);
+    with OrderEditStringGrid do begin
+      Cells[Col, Row] := IntToStr(Highest);
+      TrackerGrid.LoadPattern(Col - 1, Highest);
+    end;
   end;
 end;
 


### PR DESCRIPTION
- We got Live preview Order switching, on click, drag and double click! (double click while paused still adds new pattern, still can't undo that) #11 
- We got a scope toggle! It's in the option menus, and saves like a good option should.
- We got... minor envelope preview improvements...
- **Live preview Order switching!!!!**

![NewScopes ](https://user-images.githubusercontent.com/34431457/78025140-fbdc1200-73b5-11ea-88ee-50b4e8fe767d.gif)
