### PR TITLE
Use 2 sliders for C Volume effect, with Envelope and Volume

### DIFF
--- a/effecteditor.pas
+++ b/effecteditor.pas
@@ -365,9 +365,8 @@ end;
 
 procedure TfrmEffectEditor.fxC;
 begin
-  Notebook1.PageIndex := 0;
-  OneParamTrackBar.Max := $F;
-  LoadOneParamData;
+  Notebook1.PageIndex := 1;
+  LoadTwoParamData;
 end;
 
 procedure TfrmEffectEditor.fxD;

--- a/modimport.pas
+++ b/modimport.pas
@@ -115,6 +115,10 @@ begin
   end
   else
     case Code of
+      $9: begin
+        OutCode := $C;
+        OutParams.Value := Swap(Params);
+      end;
       $C: begin
         OutCode := $C;
         OutParams.Value := Trunc((Params / $40)*$F);

--- a/tracker.pas
+++ b/tracker.pas
@@ -2565,7 +2565,7 @@ begin
   X := EnsureRange(X, 0, WaveEditPaintBox.Width);
   Y := EnsureRange(Y, 0, WaveEditPaintBox.Height);
   if DrawingWave then begin
-    Idx := EnsureRange(Trunc((X / WaveEditPaintBox.Width)*High(TWave)), Low(TWave), High(TWave));
+    Idx := EnsureRange(Round((X / WaveEditPaintBox.Width)*High(TWave)), Low(TWave), High(TWave));
     CurrentWave^[Idx] := EnsureRange(Trunc((Y / WaveEditPaintBox.Height)*$F), 0, $F);
     UpdateHexWaveTextbox;
     WaveEditPaintBox.Invalidate;

--- a/tracker.pas
+++ b/tracker.pas
@@ -588,14 +588,14 @@ end;
 
 procedure TfrmTracker.DrawWaveform(PB: TPaintBox; Wave: TWave);
 var
-  Interval{, HInterval}: Integer;
+  Interval{, HInterval}: Single;
   I: Integer;
   W, H : Integer;
 begin
   W := PB.Width;
-  H := PB.Height;
+  H := PB.Height-4;
 
-  Interval := W div 31;
+  Interval := W / 32;
   //HInterval := H div $10;
   With PB.Canvas do begin
     Brush.Color := clGameboyBlack;
@@ -614,7 +614,7 @@ begin
     Pen.Width := 2;
     MoveTo(0, H);
     for I := Low(Wave) to High(Wave) do
-      LineTo(I*Interval, Trunc((Wave[I]/$F)*H));
+      LineTo(Round(I*Interval), Trunc((Wave[I]/$F)*H)+2);
     LineTo(W, Trunc((Wave[0]/$F)*H));
   end;
 end;
@@ -2565,8 +2565,8 @@ begin
   X := EnsureRange(X, 0, WaveEditPaintBox.Width);
   Y := EnsureRange(Y, 0, WaveEditPaintBox.Height);
   if DrawingWave then begin
-    Idx := EnsureRange(Round((X / WaveEditPaintBox.Width)*High(TWave)), Low(TWave), High(TWave));
-    CurrentWave^[Idx] := EnsureRange(Trunc((Y / WaveEditPaintBox.Height)*$F), 0, $F);
+    Idx := EnsureRange(Round((X / WaveEditPaintBox.Width)*32), Low(TWave), High(TWave));
+    CurrentWave^[Idx] := EnsureRange(Round((Y / WaveEditPaintBox.Height)*$F), 0, $F);
     UpdateHexWaveTextbox;
     WaveEditPaintBox.Invalidate;
     if PlayWaveWhileDrawingCheckbox.Checked then

--- a/utils.pas
+++ b/utils.pas
@@ -92,7 +92,12 @@ begin
     $7: Result := 'Delay note by '+P+' ticks';
     $A: Result := 'Increase volume by '+IntToStr(Params.Param1)+' units, decrease volume by '+IntToStr(Params.Param2)+' units';
     $B: Result := 'Jump to order '+P;
-    $C: Result := 'Set volume to '+P+'/15';
+    $C: begin
+    if (Params.Value < 16) then Result := 'Keep envelope, Set volume to '+IntToStr(Params.Param2)+'/15'
+    else if (Params.Value < 128) then Result := 'Envelope Down '+IntToStr(Params.Param1)+'/64Hz, Set volume to '+IntToStr(Params.Param2)+'/15'
+    else if (Params.Value < 144) then Result := 'Envelope Off, Set volume to '+IntToStr(Params.Param2)+'/15'
+    else Result := 'Envelope Up '+IntToStr(Params.Param1-8)+'/64Hz, Set volume to '+IntToStr(Params.Param2)+'/15'
+         end;
     $D: Result := 'Jump to row '+P+' on the next pattern';
     $E: Result := 'Cut note after '+P+' ticks';
     $F: Result := 'Set speed to '+P+' ticks';


### PR DESCRIPTION
Using the 2 slider page for Effect Editor when C - Set Volume is selected
Smart text for envelope up, down, no envelope, or keep instrument envelope.
![Set Vol](https://user-images.githubusercontent.com/34431457/105578335-3818ad00-5de4-11eb-87cc-fbdd6bd87d0d.gif)
![image](https://user-images.githubusercontent.com/34431457/105576934-372f4d80-5ddb-11eb-813e-d993a4b6da69.png)
Note that Noise channel may not keep the instrument envelope.

Adding a new page with Envelope graph Paint Box would be possible, but it may be cramped with 2 sliders and a box. Unsure if the same draw code needs moving out of tracker, and forgot how data was passed in pascal (if we wanted the default instrument envelope too... that may be even more complex)

Also changes The wave sample drawing box.
Uses Round for mouse to be centered on sample points.
Generates Single Float for interval spacing, which is rounded later for perfect resizing (required for mouse precision).
Uses 32 sample width to see sample 0 at start and end.
Adds 2 px offset to top and bottom of line.
![Fix Wave](https://user-images.githubusercontent.com/34431457/105578267-c04a8280-5de3-11eb-8e77-0c9bfd236161.gif)


