### PR TITLE
Improve custom font handling on Linux

### DIFF
--- a/fontconfig.pas
+++ b/fontconfig.pas
@@ -1,0 +1,22 @@
+unit FontConfig;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils;
+
+type
+  FcBool = Integer;
+
+function FcConfigAppFontAddFile(Config: Pointer; _File: PChar): FcBool; cdecl; external 'libfontconfig.so';
+
+function PangoCairoFontMapGetDefault: Pointer; cdecl; external 'libpangocairo-1.0.so' name 'pango_cairo_font_map_get_default';
+
+procedure PangoFcFontMapConfigChanged(FcFontMap: Pointer); cdecl; external 'libpangoft2-1.0.so' name 'pango_fc_font_map_config_changed';
+
+implementation
+
+end.
+

--- a/hUGETracker.lpi
+++ b/hUGETracker.lpi
@@ -221,7 +221,7 @@
         <PackageName Value="LCL"/>
       </Item5>
     </RequiredPackages>
-    <Units Count="26">
+    <Units Count="27">
       <Unit0>
         <Filename Value="hUGETracker.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -358,6 +358,11 @@
         <IsPartOfProject Value="True"/>
         <UnitName Value="DMFImport"/>
       </Unit25>
+      <Unit26>
+        <Filename Value="fontconfig.pas"/>
+        <IsPartOfProject Value="True"/>
+        <UnitName Value="FontConfig"/>
+      </Unit26>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/hUGETracker.lpr
+++ b/hUGETracker.lpr
@@ -9,6 +9,7 @@ program hUGETracker;
 uses
 {$ifdef unix}
   cthreads,
+  fontconfig,
 {$endif}
 {$ifdef MSWINDOWS}
   Windows,
@@ -30,7 +31,7 @@ uses
 
 {$ifdef MSWINDOWS}
 // https://forum.lazarus.freepascal.org/index.php?topic=39124.0
-Function AddFont    (Dir : PAnsiChar;
+function AddFont    (Dir : PAnsiChar;
                       Flag: DWORD): LongBool; StdCall;
                       External GDI32
                       Name 'AddFontResourceExA';
@@ -58,14 +59,12 @@ begin
   {$endif}
 
   {$ifdef UNIX}
-    // This is the correct way to load a font on Linux according to
-    // #linux on freenode.
-    if not DirectoryExists(GetUserDir+'.fonts') then
-      CreateDir(GetUserDir+'.fonts');
+    // This is the correct way to load a font on Linux according to... I dunno man, but this seems to work
+    if FcConfigAppFontAddFile(nil, PChar('PixeliteTTF.ttf')) = 0 then
+      Writeln(StdErr, '[ERROR] Couldn''t load Pixelite!!!');
 
-    if not (CopyFile('./PixeliteTTF.ttf', GetUserDir+'.fonts/PixeliteTTF.ttf')
-    and    (ExecuteProcess('/bin/bash', '-c fc-cache') = 0))
-    then    Writeln(StdErr, '[ERROR] Couldn''t copy Pixelite to ~/.fonts !!!');
+    PangoFcFontMapConfigChanged(PangoCairoFontMapGetDefault);
+
   {$endif}
 
   {$ifdef PRODUCTION}


### PR DESCRIPTION
- Avoid copying PixeliteTTF into user font dir
- Have font be applied during first launch

Fixes #48