### PR TITLE
Support opening ROMs read-only

### DIFF
--- a/Global/vars.pas
+++ b/Global/vars.pas
@@ -320,6 +320,7 @@ var
   S: string;
 begin
   assignfile(cf, Name);
+  Filemode:=0;
   reset(cf, 1);
   blockread(cf, {%H-}m_rom, $180);
   closefile(cf);


### PR DESCRIPTION
Otherwise, binary files may be opened RW by default, which may not play nice with permissions