### PR TITLE
Load font again on Linux and BSDs

### DIFF
--- a/hUGETracker.lpr
+++ b/hUGETracker.lpr
@@ -63,7 +63,7 @@ begin
       Writeln(StdErr, '[ERROR] Couldn''t load Pixelite!!!');
   {$endif}
 
-  {$ifdef defined(LINUX) or defined(BSD)}
+  {$if defined(LINUX) or defined(BSD)}
     // https://gitlab.gnome.org/GNOME/gtk/-/issues/3886
     if FcConfigAppFontAddFile(nil, PChar('PixeliteTTF.ttf')) = 0 then
       Writeln(StdErr, '[ERROR] Couldn''t load Pixelite!!!');


### PR DESCRIPTION
Fix typoed conditional introduced in 357b083666442cb2760c9be6c8544e5abae5c8c0