### PR TITLE
Enable full RELRO for Linux releases

### DIFF
--- a/hUGETracker.lpi
+++ b/hUGETracker.lpi
@@ -104,6 +104,8 @@
             </Debugging>
             <LinkSmart Value="True"/>
             <Options>
+              <PassLinkerOptions Value="True"/>
+              <LinkerOptions Value="-z relro -z now"/>
               <Win32>
                 <GraphicApplication Value="True"/>
               </Win32>


### PR DESCRIPTION
This increases security slightly, at the cost of resolving all dynamic relocs on startup; in practice, I couldn't notice the difference.