### PR TITLE
Switch to older Ubuntu for greater binary compat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,11 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-20.04
           - macos-10.15
           - windows-2019
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-20.04
             name: Linux
           - os: macos-10.15
             name: Mac


### PR DESCRIPTION
Fixes #123

This however does not currently compile:
```
/src/hugesettings.pas(102,35) Error: (4057) Can't determine which overloaded function to call
hugesettings.pas(118) Fatal: (10026) There were 1 errors compiling module, stopping
```

I couldn't figure the error out by myself, sorry.