### PR TITLE
trackergrid: fall back to Courier New if PixeliteTTF not found

### DIFF
--- a/src/trackergrid.pas
+++ b/src/trackergrid.pas
@@ -192,6 +192,8 @@ var
 
 implementation
 
+uses Forms;
+
 { TTableGrid }
 
 procedure TTableGrid.RenderCell(const Cell: TCell);
@@ -1338,7 +1340,15 @@ procedure TTrackerGrid.ChangeFontSize;
 begin
   // Kind of a hack
   with Canvas.Font do begin
-    Name := 'PixeliteTTF';
+    if Screen.Fonts.IndexOf('PixeliteTTF') >= 0 then begin
+       Name := 'PixeliteTTF';
+       Style := [];
+    end
+    else
+    begin
+       Name := 'Courier New';
+       Style := [fsBold];
+    end;
     Size := FontSize;
     ColumnWidth := GetTextWidth('C-5 01v64C01 ');
     RowHeight := GetTextHeight('C-5 01v64C01 ');


### PR DESCRIPTION
Currently, at least on my Linux machine, if PixeliteTTF is not installed or does not add itself during hUGETracker startup, the tracker grid will use an arbitrary default font - usually not monospaced, breaking the UI. This should allow it to cleanly fallback to "Courier New". (All Windows systems should have a font there; most Linux systems should at least have an alias to a metrically compatible font.)

This should be a further improvement to the issue discussed in https://github.com/SuperDisk/hUGETracker/issues/48 - adding another fallback layer in cast the font *still* fails to load, somehow.

Testing is required to see if the detection method works on all platforms.